### PR TITLE
Remove require pry from rake import task for heroku

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,5 +1,5 @@
 require 'csv'
-require 'pry'
+# require 'pry'
 #these need to be created in such a n order with dependencies?
 
 


### PR DESCRIPTION
Pushing our main to Heroku was being rejected. 
Removing `require pry` from rake import should fix that.