### PR TITLE
Merchant items ready to ship

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,9 +2,8 @@ class DashboardController < ApplicationController
   
   def index 
     @merchant = Merchant.find(params[:merchant_id])
-    
     @top_five_cust = @merchant.top_five_customers
-    
+    @not_shipped_items = @merchant.items_not_shipped
   end
 
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -11,6 +11,15 @@ class Merchant < ApplicationRecord
             .order(successful_transactions: :desc)
             .limit(5)
   end
+
+  def items_not_shipped
+    Invoice.joins(:items)
+             .where('merchant_id = ?', self.id)
+             .joins(:invoice_items)
+             .where('invoice_items.status != ?', 2)
+             .select("items.name, invoices.id, invoices.created_at")
+             .order("invoices.created_at")
+  end
 end
 
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -16,3 +16,16 @@
     <% end %> 
   </ol>
 </section>
+
+<section id="notShipped">
+  <h2>Items Not Shipped</h2>
+  <ul>
+    <% @not_shipped_items.each do |item| %>
+    <li><%= " #{item.name} -  Invoice  "%>
+        <%= link_to "#{item.id}", merchant_invoice_path(@merchant, item) %>
+        <%= "#{item.created_at.strftime("%A, %B %d, %Y")}" %>  
+    </li>
+    <% end %>
+  </ul>
+
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   resources :merchant, only: [:index] do
     resources :dashboard, only: [:index]
     resources :items, only: [:index, :show]
-    resources :invoices, only: [:index]
+    resources :invoices, only: [:index, :show]
   end
 
   resources :admin, only: :index

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -71,20 +71,40 @@ RSpec.describe "Merchant Dashboard" do
       
    end
 
-   xit "shows all items ready to ship" do 
-    visit "/merchant/#{@merchant.id}/dashboard"
-    # @item2 = create(:item, merchant: @merchant)
-    # @item3 = create(:item, merchant: @merchant)
-    # @item4 = create(:item, merchant: @merchant)
-    # @item5 = create(:item, merchant: @merchant)
+   it "shows all items ready to ship" do 
 
-    # binding.pry
-    # Invoice.joins(:items)
-            #  .where('merchant_id = ?', 5)
-            #  .where.not('invoice_items.status = ?', 2)
-            #  .select("items.name, invoices.id, invoices.created_at")
+    @item2 = create(:item, merchant: @merchant)
+    @item3 = create(:item, merchant: @merchant)
+
+    @invoice9 = create(:invoice, customer: @cust8)
+    @invoice10 = create(:invoice, customer: @cust3)
+    @invoice11 = create(:invoice, customer: @cust7)
+
+    @invoice_item9 = create(:invoice_item, invoice: @invoice9, item: @item2)
+    @invoice_item10 = create(:invoice_item, invoice: @invoice10, item: @item3)
+    @invoice_item11 = create(:invoice_item, invoice: @invoice11, item: @item3)
+
+    @invoice_item1.update(status: 2)
+    @invoice_item2.update(status: 2)
+    @invoice_item3.update(status: 2)
+    @invoice_item4.update(status: 2)
+    @invoice_item5.update(status: 2)
+    @invoice_item6.update(status: 2)
+    @invoice_item7.update(status: 2)
+    @invoice_item8.update(status: 2)
     
     
+
+    visit "/merchant/#{@merchant.id}/dashboard"
+
+    expect(page).to have_content(@item2.name)
+    expect(page).to have_content(@invoice9.id)
+    expect(page).to have_content(@invoice9.created_at)
+    expect(page).to have_content(@item3.name)
+    expect(page).to have_content(@invoice10.id)
+    expect(page).to have_content(@invoice10.created_at)
+    expect(page).to have_content(@invoice11.id)
+    expect(page).to have_content(@invoice11.created_at)
    end
 
     xit "and I click on the My Items link it takes me to that merchants items page" do 

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -71,6 +71,22 @@ RSpec.describe "Merchant Dashboard" do
       
    end
 
+   xit "shows all items ready to ship" do 
+    visit "/merchant/#{@merchant.id}/dashboard"
+    # @item2 = create(:item, merchant: @merchant)
+    # @item3 = create(:item, merchant: @merchant)
+    # @item4 = create(:item, merchant: @merchant)
+    # @item5 = create(:item, merchant: @merchant)
+
+    # binding.pry
+    # Invoice.joins(:items)
+            #  .where('merchant_id = ?', 5)
+            #  .where.not('invoice_items.status = ?', 2)
+            #  .select("items.name, invoices.id, invoices.created_at")
+    
+    
+   end
+
     xit "and I click on the My Items link it takes me to that merchants items page" do 
       visit "/merchant/#{@merchant.id}/dashboard"
 


### PR DESCRIPTION
Added functionality to merchant/merchant_id/dashboard page.  
Func as follows:
Create section for displaying items that have been ordered but NOT been shipped.
Shipped status is on the invoice_items table
Displays item name, invoice id number, date invoice was created in human readable format
Items listed in order from oldest to newest invoice created date
Created tests in the spec/features/merchants/dash/index_spec
Passed tests
AR method in the merchant model