### PR TITLE
Add enable and disable feature for admin merchants

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -4,7 +4,7 @@ class Admin::MerchantsController < ApplicationController
   def index
     @merchants = Merchant.all
   end
-  
+
 
   def show
   end
@@ -13,7 +13,12 @@ class Admin::MerchantsController < ApplicationController
   end
 
   def update
-    if @merchant.update(merchant_params)
+    if params[:status]
+      if @merchant.update(update_status)
+        redirect_to "/admin/merchants"
+        flash[:notice] = "#{@merchant.name}'s status changed to #{@merchant.status}"
+      end
+    elsif @merchant.update(merchant_params)
       flash[:notice] = "Information successfully updated!"
       redirect_to "/admin/merchants/#{@merchant.id}"
     else
@@ -30,5 +35,9 @@ class Admin::MerchantsController < ApplicationController
 
   def find_merchant
     @merchant = Merchant.find(params[:id])
+  end
+
+  def update_status
+    params.permit(:status)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,5 +1,6 @@
 class Merchant < ApplicationRecord
   has_many :items, dependent: :destroy
+  enum status: { enabled: 0, disabled: 1 }
 
   def top_five_customers
     Customer.joins(invoices: :items)
@@ -11,7 +12,12 @@ class Merchant < ApplicationRecord
             .order(successful_transactions: :desc)
             .limit(5)
   end
+
+  def enabled?
+    status == 'enabled'
+  end
+
+  def disabled?
+    status == 'disabled'
+  end
 end
-
-
-

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,7 +1,22 @@
 <h1>Merchants</h1>
 
 <% @merchants.each do |merchant| %>
-  <ul>
-    <a href="/admin/merchants/<%= merchant.id %>"><li><%= merchant.name %></li></a>
-  </ul>
+  <section id="merchant-<%=merchant.id%>">
+    <ul>
+      <a href="/admin/merchants/<%= merchant.id %>"><li><%= merchant.name %></li></a>
+      <p>Current Status: <%= merchant.status %></p>
+      <% if merchant.disabled? %>
+        <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |form| %>
+          <%= form.hidden_field :status, value: 'enabled'%>
+          <%= form.submit 'enable' %>
+        <% end %>
+      <% end  %>
+      <% if merchant.enabled? %>
+        <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |form| %>
+          <%= form.hidden_field :status, value: 'disabled'%>
+          <%= form.submit 'disable' %>
+        <% end %>
+      <% end  %>
+    </ul>
+  </section>
 <% end  %>

--- a/db/migrate/20210226005154_add_status_to_merchants.rb
+++ b/db/migrate/20210226005154_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :integer, default: 0 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_004538) do
+ActiveRecord::Schema.define(version: 2021_02_26_005154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_02_24_004538) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin/admin_dashboard_incomplete_invoices_spec.rb
+++ b/spec/features/admin/admin_dashboard_incomplete_invoices_spec.rb
@@ -36,7 +36,7 @@ describe 'When I visit the admin dashboard (/admin)' do
 
     expect(page).to have_link("#{@invoice_1.id}")
     click_link("#{@invoice_1.id}")
-    # save_and_open_page
+    # # save_and_open_page
     expect(current_path).to eq("/admin/invoices/#{@invoice_1.id}")
   end
 end

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Admin/invoice index' do
     end
     it 'Then I see the ID of each invoice in the system' do
       visit "/admin/invoices"
-      save_and_open_page
+      # save_and_open_page
       expect(current_path).to eq("/admin/invoices")
       expect(page).to have_content("#{@invoice_1.id}")
       expect(page).to have_content("#{@invoice_2.id}")

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -16,7 +16,7 @@ describe 'When I visit the admin invoices (/admin/invoices)' do
     expect(page).to have_link("#{@invoice_2.id}")
     expect(page).to have_content("#{@invoice_3.id}")
     expect(page).to have_link("#{@invoice_3.id}")
-    save_and_open_page
+    # save_and_open_page
 
   end
 

--- a/spec/features/admin/merchants/admin_dashboard_top_customers_spec.rb
+++ b/spec/features/admin/merchants/admin_dashboard_top_customers_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Admin Dashboard' do
       t_20 = Transaction.create!(invoice_id: inv_6.id, result: 'success')
 
       visit "/admin"
-# save_and_open_page
+
       expect(page).to have_content('Top Customers')
       expect("#{c_4.first_name} #{c_4.last_name}").to appear_before("#{c_3.first_name} #{c_3.last_name}")
       expect("#{c_3.first_name} #{c_3.last_name}").to appear_before("#{c_5.first_name} #{c_5.last_name}")

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Admin/merchant index' do
     before (:each) do
       @merchant_1 = create(:merchant)
       @merchant_2 = create(:merchant)
-      @merchant_3 = create(:merchant)
+      @merchant_3 = create(:merchant, status: 1)
       @merchant_4 = create(:merchant)
       @merchant_5 = create(:merchant)
       @merchant_6 = create(:merchant)
@@ -18,7 +18,7 @@ RSpec.describe 'Admin/merchant index' do
     end
     it 'Then I see the name of each merchant in the system' do
       visit "/admin/merchants"
-      # save_and_open_page
+      # # save_and_open_page
       expect(current_path).to eq("/admin/merchants")
       expect(page).to have_content("#{@merchant_1.name}")
       expect(page).to have_content("#{@merchant_2.name}")
@@ -28,5 +28,54 @@ RSpec.describe 'Admin/merchant index' do
       expect(page).to have_content("#{@merchant_6.name}")
       expect(page).to have_content("#{@merchant_7.name}")
     end
+
+    it 'Then next to each merchant name I see a button to disable or enable that merchant.' do
+      visit "/admin/merchants"
+
+      expect(current_path).to eq('/admin/merchants')
+
+      within("#merchant-#{@merchant_1.id}") do
+        expect(page).to have_button("disable")
+        expect(page).to have_content("#{@merchant_1.status}")
+      end
+
+      within("#merchant-#{@merchant_3.id}") do
+        expect(page).to have_button("enable")
+        expect(page).to have_content("#{@merchant_3.status}")
+      end
+    end
+
+    it 'When I click this button I am redirected back to the admin merchants index and I see the new status' do
+      visit "/admin/merchants"
+
+      expect(current_path).to eq('/admin/merchants')
+
+      within("#merchant-#{@merchant_1.id}") do
+        expect(page).to have_button("disable")
+        expect(page).to have_content("#{@merchant_1.status}")
+
+        click_button("disable")
+
+        expect(current_path).to eq('/admin/merchants')
+        expect(page).to have_content("disabled")
+      end
+
+      within("#merchant-#{@merchant_3.id}") do
+        expect(page).to have_button("enable")
+        expect(page).to have_content("#{@merchant_3.status}")
+
+        click_button("enable")
+
+        expect(current_path).to eq('/admin/merchants')
+        expect(page).to have_content("enabled")
+      end
+    end
   end
 end
+
+# As an admin,
+# When I visit the admin merchants index
+# Then next to each merchant name I see a button to disable or enable that merchant.
+# When I click this button
+# Then I am redirected back to the admin merchants index
+# And I see that the merchant's status has changed

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -19,7 +19,7 @@ describe 'When I visit the admin merchants (/admin/merchants)' do
     expect(page).to have_link("#{@merchant_2.name}")
     expect(page).to have_content("#{@merchant_3.name}")
     expect(page).to have_link("#{@merchant_3.name}")
-    save_and_open_page
+    # save_and_open_page
 
   end
 

--- a/spec/features/admin/merchants/update_spec.rb
+++ b/spec/features/admin/merchants/update_spec.rb
@@ -27,7 +27,7 @@ describe 'When I visit a merchants admin show page' do
     visit "/admin/merchants/#{@merchant_1.id}"
 
     expect(current_path).to eq("/admin/merchants/#{@merchant_1.id}")
-    save_and_open_page
+    # save_and_open_page
     click_button("Update Merchant")
     expect(page).to have_field('name')
     fill_in "name", :with => "New Merchant Name"


### PR DESCRIPTION
Kyle and I added the test and feature to enable/disable merchants. 
Helper methods added for `merchant.enabled?` and merchant.disabled?` so that the view can be cleaner.
Bonus feature, we are only displaying the button that applies: If enabled, you only see the disable option and vice versa. 