### PR TITLE
Complete admin merchants grouped by status feature

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -15,11 +15,11 @@ class Merchant < ApplicationRecord
 
   def items_not_shipped
     Invoice.joins(:items)
-             .where('merchant_id = ?', self.id)
-             .joins(:invoice_items)
-             .where('invoice_items.status != ?', 2)
-             .select("items.name, invoices.id, invoices.created_at")
-             .order("invoices.created_at")
+           .where('merchant_id = ?', self.id)
+           .joins(:invoice_items)
+           .where('invoice_items.status != ?', 2)
+           .select("items.name, invoices.id, invoices.created_at")
+           .order("invoices.created_at")
   end
 
   def enabled?
@@ -28,5 +28,13 @@ class Merchant < ApplicationRecord
 
   def disabled?
     status == 'disabled'
+  end
+
+  def self.display_enabled
+    where(status: 0)
+  end
+
+  def self.display_disabled
+    where(status: 1)
   end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,23 +1,40 @@
 <a href="/admin/merchants/new">New Merchant</a>
 <h1>Merchants</h1>
 
-<% @merchants.each do |merchant| %>
+<section id="enabled-merchants">
+<h2>Enabled Merchants</h2>
+<% @merchants.display_enabled.each do |merchant| %>
   <section id="merchant-<%=merchant.id%>">
     <ul>
       <a href="/admin/merchants/<%= merchant.id %>"><li><%= merchant.name %></li></a>
       <p>Current Status: <%= merchant.status %></p>
-      <% if merchant.disabled? %>
-        <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |form| %>
-          <%= form.hidden_field :status, value: 'enabled'%>
-          <%= form.submit 'enable' %>
-        <% end %>
-      <% end  %>
+
       <% if merchant.enabled? %>
         <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |form| %>
           <%= form.hidden_field :status, value: 'disabled'%>
           <%= form.submit 'disable' %>
         <% end %>
       <% end  %>
-    </ul>
+      </ul>
   </section>
-<% end  %>
+<% end %>
+</section>
+
+<section id="disabled-merchants">
+<h2>Disabled Merchants</h2>
+<% @merchants.display_disabled.each do |merchant| %>
+  <section id="merchant-<%=merchant.id%>">
+    <ul>
+      <a href="/admin/merchants/<%= merchant.id %>"><li><%= merchant.name %></li></a>
+      <p>Current Status: <%= merchant.status %></p>
+
+      <% if merchant.disabled? %>
+        <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |form| %>
+          <%= form.hidden_field :status, value: 'enabled'%>
+          <%= form.submit 'enable' %>
+        <% end %>
+      <% end  %>
+      </ul>
+  </section>
+<% end %>
+</section>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -76,5 +76,33 @@ RSpec.describe 'Admin/merchant index' do
 
       expect(page).to have_link("New Merchant")
     end
+
+    it "Displays two sections for 'Enabled Merchants' and 'Disabled Merchants'" do
+      visit "/admin/merchants"
+
+      expect(page).to have_content("Enabled Merchants")
+      expect(page).to have_content("Disabled Merchants")
+    end
+
+    it 'And I see that each Merchant is listed in the appropriate section' do
+      Merchant.destroy_all
+      merchant_1 = create(:merchant, status: 0)
+      merchant_2 = create(:merchant, status: 1)
+      merchant_3 = create(:merchant, status: 1)
+      merchant_4 = create(:merchant, status: 1)
+      merchant_5 = create(:merchant, status: 0)
+      visit "/admin/merchants"
+
+      within("#enabled-merchants") do
+        expect(page).to have_content("#{merchant_1.name}")
+        expect(page).to have_content("#{merchant_5.name}")
+      end
+
+      within("#disabled-merchants") do
+        expect(page).to have_content("#{merchant_2.name}")
+        expect(page).to have_content("#{merchant_3.name}")
+        expect(page).to have_content("#{merchant_4.name}")
+      end
+    end
   end
 end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'Admin/merchant new' do
 
       expect(current_path).to eq("/admin/merchants")
       expect(page).to have_content("New Merchant")
-save_and_open_page
       expect(page).to have_content("disable")
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -4,4 +4,34 @@ RSpec.describe Merchant, type: :model do
   describe "relationships" do
     it { should have_many :items }
   end
+
+  describe "class methods" do
+    describe '::display_enabled' do
+      it 'displays merchants that have an enabled status' do
+        merchant_1 = create(:merchant, status: 0)
+        merchant_2 = create(:merchant, status: 0)
+        merchant_3 = create(:merchant, status: 1)
+        merchant_4 = create(:merchant, status: 1)
+        merchant_5 = create(:merchant, status: 0)
+        merchant_6 = create(:merchant, status: 0)
+        merchant_7 = create(:merchant, status: 1)
+
+        expect((Merchant.display_enabled).count).to eq(4)
+      end
+    end
+
+    describe '::display_disabled' do
+      it 'displays merchants that have a disabled status' do
+        merchant_1 = create(:merchant, status: 0)
+        merchant_2 = create(:merchant, status: 0)
+        merchant_3 = create(:merchant, status: 1)
+        merchant_4 = create(:merchant, status: 1)
+        merchant_5 = create(:merchant, status: 0)
+        merchant_6 = create(:merchant, status: 0)
+        merchant_7 = create(:merchant, status: 1)
+
+        expect((Merchant.display_disabled).count).to eq(3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Tests 
- created for `::display_enabled`
- created for `::display_disabled`


This completes user story **Admin Merchants Grouped by Status #182**
### Notes 
- Created two class methods for merchant `::display_enabled` and `::display_disabled`
- Should we remove the "Current Status: enabled" line form the `app/views/admin/merchants/index.html.erb`? 